### PR TITLE
feat: add internal queue system to manage updates of kvring data

### DIFF
--- a/certstore/account.go
+++ b/certstore/account.go
@@ -180,7 +180,7 @@ func Setup(logger log.Logger, cfg config.Config, version string) error {
 		}
 
 		if issuerConf.HTTPChallenge != "" {
-			httpProvider, err := NewHTTPChallengeProviderByName(issuerConf.HTTPChallenge, issuerConf.HTTPChallengeCfg)
+			httpProvider, err := NewHTTPChallengeProviderByName(issuerConf.HTTPChallenge, issuerConf.HTTPChallengeCfg, logger)
 			if err != nil {
 				_ = level.Error(logger).Log("err", err)
 				return err
@@ -199,7 +199,7 @@ func Setup(logger log.Logger, cfg config.Config, version string) error {
 }
 
 // NewHTTPChallengeProviderByName Factory for HTTP providers.
-func NewHTTPChallengeProviderByName(name, config string) (challenge.Provider, error) {
+func NewHTTPChallengeProviderByName(name, config string, logger log.Logger) (challenge.Provider, error) {
 	switch name {
 	case "memcached":
 		return memcached.NewMemcachedProvider(strings.Split(config, ","))
@@ -208,7 +208,7 @@ func NewHTTPChallengeProviderByName(name, config string) (challenge.Provider, er
 	case "webroot":
 		return webroot.NewHTTPProvider(config)
 	case "kvring":
-		return NewKVRingProvider()
+		return NewKVRingProvider(logger)
 	default:
 		return nil, fmt.Errorf("unrecognized HTTP provider: %s", name)
 	}

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -23,10 +23,10 @@ import (
 )
 
 var (
-	AmRingKey          = "collectors/cert"
-	AmRingChallengeKey = "collectors/challenge"
-	TokenRingKey       = "collectors/token"
-	AmStore            *CertStore
+	AmCertificateRingKey = "collectors/certificate"
+	AmChallengeRingKey   = "collectors/challenge"
+	AmTokenRingKey       = "collectors/token"
+	AmStore              *CertStore
 )
 
 type CertStore struct {
@@ -127,7 +127,7 @@ func CreateRemoteCertificateResource(certData Certificate, logger log.Logger) (C
 	}
 
 	if certData.HTTPChallenge != "" {
-		httpProvider, err := NewHTTPChallengeProviderByName(certData.HTTPChallenge, "")
+		httpProvider, err := NewHTTPChallengeProviderByName(certData.HTTPChallenge, "", logger)
 		if err != nil {
 			_ = level.Error(logger).Log("err", err)
 			return certData, err
@@ -209,8 +209,8 @@ func DeleteRemoteCertificateResource(certData Certificate, logger log.Logger) er
 	return nil
 }
 
-func CheckCertExpiration(amStore *CertStore, logger log.Logger) error {
-	data, err := amStore.GetKVRingCert(AmRingKey)
+func CheckCertExpiration(amStore *CertStore, logger log.Logger, isLeader bool) error {
+	data, err := amStore.GetKVRingCert(AmCertificateRingKey, isLeader)
 	if err != nil {
 		_ = level.Error(logger).Log("err", err)
 		return err
@@ -249,7 +249,7 @@ func CheckCertExpiration(amStore *CertStore, logger log.Logger) error {
 		}
 	}
 	if hasChange {
-		amStore.PutKVRing(AmRingKey, dataCopy)
+		amStore.PutKVRing(AmCertificateRingKey, dataCopy)
 	}
 	return nil
 }

--- a/certstore/http_challenge.go
+++ b/certstore/http_challenge.go
@@ -3,22 +3,32 @@ package certstore
 
 import (
 	"github.com/go-acme/lego/v4/challenge/http01"
+	"github.com/go-kit/log"
 
 	"github.com/fgouteroux/acme_manager/queue"
+	"github.com/fgouteroux/acme_manager/ring"
 )
 
 // HTTPProvider implements HTTPProvider for `http-01` challenge.
-type HTTPProvider struct{}
+type HTTPProvider struct {
+	logger log.Logger
+}
 
 // NewMemcacheProvider returns a HTTPProvider instance with a configured webroot path.
-func NewKVRingProvider() (*HTTPProvider, error) {
-	return &HTTPProvider{}, nil
+func NewKVRingProvider(logger log.Logger) (*HTTPProvider, error) {
+	return &HTTPProvider{logger: logger}, nil
 }
 
 // Present makes the token available at `HTTP01ChallengePath(token)` by creating the key in the kvring.
 func (w *HTTPProvider) Present(_, token, keyAuth string) error {
 	action := func() error {
-		data, err := AmStore.GetKVRingMapString(AmRingChallengeKey)
+
+		isLeader, err := ring.IsLeader(AmStore.RingConfig)
+		if err != nil {
+			return err
+		}
+
+		data, err := AmStore.GetKVRingMapString(AmChallengeRingKey, isLeader)
 		if err != nil {
 			return err
 		}
@@ -29,14 +39,14 @@ func (w *HTTPProvider) Present(_, token, keyAuth string) error {
 
 		data[http01.ChallengePath(token)] = keyAuth
 
-		AmStore.PutKVRing(AmRingChallengeKey, data)
+		AmStore.PutKVRing(AmChallengeRingKey, data)
 		return nil
 	}
 
 	ChallengeQueue.AddJob(queue.Job{
 		Name:   http01.ChallengePath(token),
 		Action: action,
-	})
+	}, w.logger)
 
 	return nil
 }
@@ -45,21 +55,27 @@ func (w *HTTPProvider) Present(_, token, keyAuth string) error {
 func (w *HTTPProvider) CleanUp(_, token, _ string) error {
 
 	action := func() error {
-		data, err := AmStore.GetKVRingMapString(AmRingChallengeKey)
+
+		isLeader, err := ring.IsLeader(AmStore.RingConfig)
+		if err != nil {
+			return err
+		}
+
+		data, err := AmStore.GetKVRingMapString(AmChallengeRingKey, isLeader)
 		if err != nil {
 			return err
 		}
 
 		delete(data, http01.ChallengePath(token))
 
-		AmStore.PutKVRing(AmRingChallengeKey, data)
+		AmStore.PutKVRing(AmChallengeRingKey, data)
 		return nil
 	}
 
 	ChallengeQueue.AddJob(queue.Job{
 		Name:   http01.ChallengePath(token),
 		Action: action,
-	})
+	}, w.logger)
 
 	return nil
 }

--- a/certstore/startup.go
+++ b/certstore/startup.go
@@ -23,33 +23,71 @@ var (
 )
 
 func OnStartup(logger log.Logger) error {
+
+	// init queues
+	CertificateQueue = queue.NewQueue("certificate")
+	ChallengeQueue = queue.NewQueue("challenge")
+	TokenQueue = queue.NewQueue("token")
+
+	// init workers
+	tokenWorker := queue.NewWorker(TokenQueue, logger)
+	challengeWorker := queue.NewWorker(ChallengeQueue, logger)
+	certificateWorker := queue.NewWorker(CertificateQueue, logger)
+
+	// start workers
+	go tokenWorker.DoWork()
+	go certificateWorker.DoWork()
+	go challengeWorker.DoWork()
+
+	// init local cache
+	localCache.Set(AmCertificateRingKey, "")
+	localCache.Set(AmTokenRingKey, "")
+	localCache.Set(AmChallengeRingKey, "")
+
 	isLeaderNow, err := ring.IsLeader(AmStore.RingConfig)
 	if err != nil {
 		_ = level.Warn(logger).Log("msg", "Failed to determine the ring leader", "err", err)
 		return err
 	}
 
-	data, err := AmStore.GetKVRing(AmRingKey)
+	certificateData, err := AmStore.GetKVRing(AmCertificateRingKey, isLeaderNow)
 	if err != nil {
 		_ = level.Error(logger).Log("err", err)
 		return err
 	}
 
-	tokenData, err := AmStore.GetKVRingToken(TokenRingKey)
+	tokenData, err := AmStore.GetKVRingToken(AmTokenRingKey, isLeaderNow)
 	if err != nil {
 		_ = level.Error(logger).Log("err", err)
 		return err
 	}
-	if len(tokenData) == 0 {
+
+	challengeData, err := AmStore.GetKVRingMapString(AmChallengeRingKey, isLeaderNow)
+	if err != nil {
+		return err
+	}
+	if challengeData != nil {
+		// update local cache
+		content, _ := json.Marshal(challengeData)
+		localCache.Set(AmCertificateRingKey, string(content))
+	}
+
+	if len(tokenData) == 0 && isLeaderNow {
+		tokens := getVaultAllToken(logger)
+
+		// update local cache
+		content, _ := json.Marshal(tokens)
+		localCache.Set(AmTokenRingKey, content)
+
 		// udpate kv store
-		AmStore.PutKVRing(TokenRingKey, getVaultAllToken(logger))
+		AmStore.PutKVRing(AmTokenRingKey, tokens)
+	} else {
+		// update local cache
+		content, _ := json.Marshal(tokenData)
+		localCache.Set(AmCertificateRingKey, string(content))
 	}
 
-	if len(data) == 0 {
-		if !isLeaderNow {
-			_ = level.Debug(logger).Log("msg", "Skipping because this node is not the ring leader")
-			return nil
-		}
+	if len(certificateData) == 0 && isLeaderNow {
 
 		vaultCertList := getVaultAllCertificate(logger)
 
@@ -59,24 +97,16 @@ func OnStartup(logger log.Logger) error {
 		}
 		content = vaultCertList
 
+		// update local cache
+		localCache.Set(AmCertificateRingKey, content)
+
 		// udpate kv store
-		AmStore.PutKVRing(AmRingKey, content)
+		AmStore.PutKVRing(AmCertificateRingKey, content)
+	} else {
+		// update local cache
+		content, _ := json.Marshal(certificateData)
+		localCache.Set(AmCertificateRingKey, string(content))
 	}
-
-	// init queues
-	CertificateQueue = queue.NewQueue("certificate")
-	ChallengeQueue = queue.NewQueue("challenge")
-	TokenQueue = queue.NewQueue("token")
-
-	// init workers
-	tokenWorker := queue.NewWorker(TokenQueue)
-	challengeWorker := queue.NewWorker(ChallengeQueue)
-	certificateWorker := queue.NewWorker(CertificateQueue)
-
-	// start workers
-	go tokenWorker.DoWork()
-	go certificateWorker.DoWork()
-	go challengeWorker.DoWork()
 
 	return nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -136,7 +136,7 @@ type certificateHandlerData struct {
 
 func certificateListHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, err := certstore.AmStore.GetKVRingCert(certstore.AmRingKey)
+		data, err := certstore.AmStore.GetKVRingCert(certstore.AmCertificateRingKey, false)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -175,7 +175,7 @@ func certificateListHandler() http.HandlerFunc {
 }
 
 func httpChallengeHandler(w http.ResponseWriter, r *http.Request) {
-	data, err := certstore.AmStore.GetKVRingMapString(certstore.AmRingChallengeKey)
+	data, err := certstore.AmStore.GetKVRingMapString(certstore.AmChallengeRingKey, false)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -197,7 +197,7 @@ type tokenHandlerData struct {
 
 func tokenListHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, err := certstore.AmStore.GetKVRingToken(certstore.TokenRingKey)
+		data, err := certstore.AmStore.GetKVRingToken(certstore.AmTokenRingKey, false)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/main.go
+++ b/main.go
@@ -260,6 +260,10 @@ func main() {
 	http.Handle("GET /api/v1/token/{id}", LoggerHandler(api.GetTokenHandler(logger)))
 	http.Handle("DELETE /api/v1/token/{id}", LoggerHandler(api.RevokeTokenHandler(logger, proxyClient)))
 
+	// update local cache on kv ring changes
+	certstore.WatchRingKvStoreChanges(ringConfig, logger)
+
+	// check token expired
 	go certstore.WatchTokenExpiration(logger, *checkTokenInterval)
 
 	// renewal certificate

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -1,0 +1,43 @@
+package memcache
+
+import (
+	"sync"
+)
+
+type MemCache struct {
+	data map[string]CacheValue
+	lock sync.Mutex
+}
+
+type CacheValue struct {
+	Value interface{}
+}
+
+func NewLocalCache() *MemCache {
+	return &MemCache{
+		data: make(map[string]CacheValue),
+	}
+}
+
+func (c *MemCache) Set(key string, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.data[key] = CacheValue{
+		Value: value,
+	}
+}
+
+func (c *MemCache) Get(key string) (CacheValue, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	value, found := c.data[key]
+	return value, found
+}
+
+func (c *MemCache) Del(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.data, key)
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,0 +1,101 @@
+package queue
+
+import (
+	"context"
+	"log"
+	"sync"
+)
+
+// Queue holds name, list of jobs and context with cancel.
+type Queue struct {
+	name   string
+	jobs   chan Job
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// Job - holds logic to perform some operations during queue execution.
+type Job struct {
+	Name   string
+	Action func() error
+}
+
+// Worker responsible for queue serving.
+type Worker struct {
+	Queue *Queue
+}
+
+// NewQueue instantiates new queue.
+func NewQueue(name string) *Queue {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Queue{
+		jobs:   make(chan Job),
+		name:   name,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// AddJobs adds jobs to the queue and cancels channel.
+func (q *Queue) AddJobs(jobs []Job) {
+	var wg sync.WaitGroup
+	wg.Add(len(jobs))
+
+	for _, job := range jobs {
+		go func(job Job) {
+			q.AddJob(job)
+			wg.Done()
+		}(job)
+	}
+
+	go func() {
+		wg.Wait()
+		q.cancel()
+	}()
+
+}
+
+// AddJob sends job to the channel.
+func (q *Queue) AddJob(job Job) {
+	q.jobs <- job
+	log.Printf("New job %s added to %s queue", job.Name, q.name)
+}
+
+// Run performs job execution.
+func (j Job) Run() error {
+	log.Printf("Job running: %s", j.Name)
+
+	err := j.Action()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewWorker initialises new Worker.
+func NewWorker(queue *Queue) *Worker {
+	return &Worker{
+		Queue: queue,
+	}
+}
+
+// DoWork processes jobs from the queue (jobs channel).
+func (w *Worker) DoWork() bool {
+	for {
+		select {
+		// if context was canceled.
+		case <-w.Queue.ctx.Done():
+			log.Printf("Work done in queue %s: %s!", w.Queue.name, w.Queue.ctx.Err())
+			return true
+		// if job received.
+		case job := <-w.Queue.jobs:
+			err := job.Run()
+			if err != nil {
+				log.Print(err)
+				continue
+			}
+		}
+	}
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -2,8 +2,11 @@ package queue
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 )
 
 // Queue holds name, list of jobs and context with cancel.
@@ -22,7 +25,8 @@ type Job struct {
 
 // Worker responsible for queue serving.
 type Worker struct {
-	Queue *Queue
+	Queue  *Queue
+	Logger log.Logger
 }
 
 // NewQueue instantiates new queue.
@@ -38,13 +42,13 @@ func NewQueue(name string) *Queue {
 }
 
 // AddJobs adds jobs to the queue and cancels channel.
-func (q *Queue) AddJobs(jobs []Job) {
+func (q *Queue) AddJobs(jobs []Job, logger log.Logger) {
 	var wg sync.WaitGroup
 	wg.Add(len(jobs))
 
 	for _, job := range jobs {
 		go func(job Job) {
-			q.AddJob(job)
+			q.AddJob(job, logger)
 			wg.Done()
 		}(job)
 	}
@@ -57,27 +61,30 @@ func (q *Queue) AddJobs(jobs []Job) {
 }
 
 // AddJob sends job to the channel.
-func (q *Queue) AddJob(job Job) {
+func (q *Queue) AddJob(job Job, logger log.Logger) {
+	_ = level.Debug(logger).Log("msg", fmt.Sprintf("Adding job '%s' to queue '%s", job.Name, q.name))
 	q.jobs <- job
-	log.Printf("New job %s added to %s queue", job.Name, q.name)
 }
 
 // Run performs job execution.
-func (j Job) Run() error {
-	log.Printf("Job running: %s", j.Name)
+func (j Job) Run(logger log.Logger) error {
+	_ = level.Debug(logger).Log("msg", fmt.Sprintf("Job running: %s", j.Name))
 
 	err := j.Action()
 	if err != nil {
 		return err
 	}
 
+	_ = level.Debug(logger).Log("msg", fmt.Sprintf("Job ending: %s", j.Name))
+
 	return nil
 }
 
 // NewWorker initialises new Worker.
-func NewWorker(queue *Queue) *Worker {
+func NewWorker(queue *Queue, logger log.Logger) *Worker {
 	return &Worker{
-		Queue: queue,
+		Queue:  queue,
+		Logger: logger,
 	}
 }
 
@@ -87,13 +94,13 @@ func (w *Worker) DoWork() bool {
 		select {
 		// if context was canceled.
 		case <-w.Queue.ctx.Done():
-			log.Printf("Work done in queue %s: %s!", w.Queue.name, w.Queue.ctx.Err())
+			_ = level.Debug(w.Logger).Log("msg", fmt.Sprintf("Work done in queue %s: %s!", w.Queue.name, w.Queue.ctx.Err()))
 			return true
 		// if job received.
 		case job := <-w.Queue.jobs:
-			err := job.Run()
+			err := job.Run(w.Logger)
 			if err != nil {
-				log.Print(err)
+				_ = level.Error(w.Logger).Log("err", err)
 				continue
 			}
 		}


### PR DESCRIPTION
As updating kvring data could take some time to propagate ring notification, we must find a way to get the last update of the kv data, otherwise we could overwrite the data when calling the func [KV Get](https://pkg.go.dev/github.com/grafana/dskit@v0.0.0-20250122122458-53db97b18080/kv/memberlist#KV.Get).

To ensure the atomic update of the kv ring data, we setup an internal memory queue system based on channel with only one worker, and we rely on local memory cache to have the last update of the kv data. The leader is still responsible to update the kv ring data and now also for the local memory cache, which is updated or the peers when kv ring key changes. 
