### PR TITLE
feat: client allow backup cert/key to vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ storage:
     secret_id: "secret_id_value"
     url: " https://vault.example.com"
     secret_engine: "myengine"
-    secret_prefix: "acme"
     certificate_prefix: "certificates"
     token_prefix: "tokens"
     mount_path: "login/approle"
@@ -389,6 +388,7 @@ ts=2025-01-10T10:18:49.174Z caller=main.go:271 level=info msg="TLS is disabled."
 
 Optional Common parameters:
 - **certificate_deploy** (bool): If set to true, deploy certificate and private key in given `certificate_dir`
+- **certificate_backup** (bool): If set to true, backup certificate and private key in given storage `vault` config
 - **certificate_dir** (string): Directory in which to deploy issuers certificates and private keys
 - **certificate_dir_perm** (uint32): Unix permission for certificate directory in octal format (default: 0700)
 - **certificate_file_perm** (uint32): Unix permission for certificate file in octal format (default: 0600)
@@ -412,15 +412,25 @@ Optional Certificate parameters:
 - **dns_challenge** (string): dns challenge name to use for domain validation
 - **labels** (key=value string, comma separated): labels to attach to the certificate, used by the metric `acme_manager_certificate_info`
 
+
 ```
 common:
   certificate_deploy: true
+  certificate_backup: true
   certificate_dir: /etc/myapp/ssl/
 
   cmd_enabled: true
   post_cmd_run: /usr/bin/systemcl reload myapp
   post_cmd_timeout: 30
 
+storage:
+  vault:
+    role_id: "role_id_value"
+    secret_id: "secret_id_value"
+    url: " https://vault.example.com"
+    secret_engine: "myengine"
+    certificate_prefix: "backup/certificates"
+    mount_path: "login/approle"
 
 certificate:
   - domain: testfgx01.example.com

--- a/api/token.go
+++ b/api/token.go
@@ -71,6 +71,18 @@ type TokenResponseGet struct {
 // @security APIKeyAuth
 func GetTokenHandler(logger log.Logger) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Header.Get("Authorization") != "" && r.PathValue("id") == "self" {
+			tokenData, err := checkAuth(r)
+			if err != nil {
+				_ = level.Error(logger).Log("err", err)
+				responseJSON(w, nil, err, http.StatusUnauthorized)
+				return
+			}
+			responseJSON(w, tokenData, nil, http.StatusOK)
+			return
+		}
+
 		authHeader := r.Header.Get("X-API-Key")
 		if authHeader == "" {
 			responseJSON(w, nil, fmt.Errorf("X-API-Key Header is missing or empty"), http.StatusUnauthorized)

--- a/client/config.go
+++ b/client/config.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 
 	"github.com/fgouteroux/acme_manager/certstore"
+	cfg "github.com/fgouteroux/acme_manager/config"
 	"github.com/fgouteroux/acme_manager/utils"
 )
 
@@ -12,12 +13,14 @@ import (
 type Config struct {
 	Common      Common                  `yaml:"common"`
 	Certificate []certstore.Certificate `yaml:"certificate"`
+	Storage     cfg.Storage             `yaml:"storage"`
 }
 
 // Common represents common config.
 type Common struct {
 	CertDays        int         `yaml:"cert_days"`
 	CertDaysRenewal int         `yaml:"cert_days_renewal"`
+	CertBackup      bool        `yaml:"certificate_backup"`
 	CertDeploy      bool        `yaml:"certificate_deploy"`
 	CertDir         string      `yaml:"certificate_dir"`
 	CertDirPerm     fs.FileMode `yaml:"certificate_dir_perm"`

--- a/restclient/restclient.go
+++ b/restclient/restclient.go
@@ -291,3 +291,29 @@ func (c *Client) DeleteCertificate(issuer, domain string, revoke bool) error {
 
 	return nil
 }
+
+func (c *Client) GetSelfToken() (certstore.Token, error) {
+	var token certstore.Token
+	headers := make(map[string]string, 1)
+	headers["Authorization"] = "Bearer " + c.Token
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	baseErrMsg := "error getting self token"
+
+	resp, err := c.doRequest(ctx, "GET", "/token/self", headers, nil)
+	if err != nil {
+		return token, fmt.Errorf("%s - %v", baseErrMsg, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return token, fmt.Errorf("%s: %s - %v", baseErrMsg, resp.Status, err)
+	}
+
+	if err := c.decodeJSON(resp, &token); err != nil {
+		return token, fmt.Errorf("%s - %v", baseErrMsg, err)
+	}
+
+	return token, nil
+}


### PR DESCRIPTION
Add client `certificate_backup` option to allow backup certificate and private key into vault.

This allow to restore private key file from vault if local file has been manually deleted and avoid certificate recreation.

Allow to reuse local private key file if exists, otherwise generate a new private key.