### PR TITLE
feat: add random renewal_date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ config.yml.local*
 etc
 accounts
 .env
+.run
 certificates
 TODO

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 
 checksum:
   name_template: 'checksums.txt'

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 	golangci-lint run
 
 security:
-	gosec -exclude-dir _local -quiet ./...
+	gosec -exclude=G401,G404,G505 -exclude-dir _local -quiet ./...
 
 build:
 	goreleaser build --snapshot --clean

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Required parameters:
 
 Optional parameters:
 - **bundle** (bool): if true, add the issuers certificate to the new certificate
-- **renewal_days** (int): number of days before automatic certificate renewal
+- **renewal_days** (string): number of days or interval of days before automatic certificate renewal
 - **days** (int): number of days before certificate expiration
 - **san** (string, comma separated): DNS domain names to add to certificate
 - **http_challenge** (string): http challenge name to use for domain validation
@@ -305,7 +305,7 @@ curl -X 'POST' \
   "dns_challenge": "ns1",
   "domain": "testfgx01.example.com",
   "issuer": "letsencrypt",
-  "renewal_days": 30,
+  "renewal_days": "30",
   "csr": "LS0..."
 }'
 
@@ -332,7 +332,7 @@ curl -X 'PUT' \
   "dns_challenge": "ns1",
   "domain": "testfgx01.example.com",
   "issuer": "letsencrypt",
-  "renewal_days": 30,
+  "renewal_days": "30",
   "san": "testfgx02.example.com",
   "csr": "LS0..."
 }'
@@ -410,7 +410,7 @@ Optional Common parameters:
  
 Optional Certificate parameters:
 - **bundle** (bool): if true, add the issuers certificate to the new certificate
-- **renewal_days** (int): number of days before automatic certificate renewal
+- **renewal_days** (string): number of days or interval of days before automatic certificate renewal
 - **days** (int): number of days before certificate expiration
 - **san** (string, comma separated): DNS domain names to add to certificate
 - **http_challenge** (string): http challenge name to use for domain validation

--- a/client/config.go
+++ b/client/config.go
@@ -21,7 +21,7 @@ type Config struct {
 // Common represents common config.
 type Common struct {
 	CertDays          int         `yaml:"cert_days"`
-	CertDaysRenewal   int         `yaml:"cert_days_renewal"`
+	CertDaysRenewal   string      `yaml:"cert_days_renewal"`
 	CertBackup        bool        `yaml:"certificate_backup"`
 	CertDeploy        bool        `yaml:"certificate_deploy"`
 	CertDir           string      `yaml:"certificate_dir"`
@@ -48,8 +48,10 @@ func (s *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if s.Common.CertDaysRenewal == 0 {
-		s.Common.CertDaysRenewal = 30
+	if s.Common.CertDaysRenewal == "" {
+		s.Common.CertDaysRenewal = "20-30"
+	} else if _, _, err := utils.ValidateRenewalDays(s.Common.CertDaysRenewal); err != nil {
+		return err
 	}
 
 	if s.Common.CertDirPerm == 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/fgouteroux/acme_manager/utils"
+
 	"golang.org/x/exp/maps"
 )
 
@@ -20,7 +23,7 @@ type Config struct {
 // Common represents common config.
 type Common struct {
 	APIKeyHash          string `yaml:"api_key_hash"`
-	CertDaysRenewal     int    `yaml:"cert_days_renewal"`
+	CertDaysRenewal     string `yaml:"cert_days_renewal"`
 	RootPathAccount     string `yaml:"rootpath_account"`
 	RootPathCertificate string `yaml:"rootpath_certificate"`
 }
@@ -62,8 +65,10 @@ func (s *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if s.Common.CertDaysRenewal == 0 {
-		s.Common.CertDaysRenewal = 30
+	if s.Common.CertDaysRenewal == "" {
+		s.Common.CertDaysRenewal = "20-30"
+	} else if _, _, err := utils.ValidateRenewalDays(s.Common.CertDaysRenewal); err != nil {
+		return err
 	}
 
 	for issuer, issuerConf := range s.Issuer {

--- a/ring/json_codec.go
+++ b/ring/json_codec.go
@@ -17,7 +17,7 @@ type Data struct {
 // Merge implements the memberlist.Mergeable interface.
 // It allow to merge the content of two different data.
 // We dont need to compare values to know if a change is requested as the leader only could send a message
-func (c *Data) Merge(mergeable memberlist.Mergeable, _ bool) (change memberlist.Mergeable, error error) {
+func (c *Data) Merge(mergeable memberlist.Mergeable, _ bool) (memberlist.Mergeable, error) {
 	if mergeable == nil {
 		return nil, nil
 	}

--- a/templates/certificate.gohtml
+++ b/templates/certificate.gohtml
@@ -38,6 +38,7 @@
         <th>SAN</th>
         <th>Duration</th>
         <th>Renew days</th>
+        <th>Renewal date</th>
         <th>Labels</th>
       </tr>
     </thead>
@@ -60,11 +61,12 @@
         {{ else }}
         <td id="days">{{ $cert.Days }}d</td>
         {{ end }}
-        {{ if eq $cert.RenewalDays 0 }}
-        <td id="renewal_days">30d</td>
+        {{ if $cert.RenewalDays }}
+        <td id="renewal_days">{{ $cert.RenewalDays }}</td>
         {{ else }}
-        <td id="renewal_days">{{ $cert.RenewalDays }}d</td>
+        <td id="renewal_days">20-30</td>
         {{ end }}
+        <td id="renewal">{{ $cert.RenewalDate }}</td>
         {{ if $cert.Labels }}
         <td id="labels">{{ range $item := Split $cert.Labels "," }}{{ $item }}<br>{{ end }}</td>
         {{ end }}


### PR DESCRIPTION
Now it's possible to pass an interval of days to do the renewal.

When a certificate is created or updated it use the `renewal_days` and generate a random date, hour and minutes for the renewal (sathurday and sunday are skipped from random day).

This randomisation allow renewal certificates not at the same time.

I initially want to implement the [ACME ARI ](https://datatracker.ietf.org/doc/draft-ietf-acme-ari/) but it doesn't fit my case because it replace the old cert with a revoke.