### PR TITLE
Align log message fields consistently

### DIFF
--- a/client/watcher.go
+++ b/client/watcher.go
@@ -39,7 +39,7 @@ func WatchCertificateFromRing(logger log.Logger, interval time.Duration, configP
 func WatchCertificateEventChange(logger log.Logger, configPath string, acmeClient *restclient.Client) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		_ = level.Error(logger).Log("err", err)
+		_ = level.Error(logger).Log("msg", "failed to create file watcher", "err", err)
 		os.Exit(1)
 	}
 	defer watcher.Close()
@@ -53,7 +53,7 @@ func WatchCertificateEventChange(logger log.Logger, configPath string, acmeClien
 	// watch the parent dir of the file to catch changes
 	err = watcher.Add(watchDir)
 	if err != nil {
-		_ = level.Error(logger).Log("err", err)
+		_ = level.Error(logger).Log("msg", "failed to watch directory", "path", watchDir, "err", err)
 		os.Exit(1)
 	}
 
@@ -70,7 +70,7 @@ func WatchCertificateEventChange(logger log.Logger, configPath string, acmeClien
 				go CheckCertificate(logger, configPath, acmeClient)
 			}
 		case err := <-watcher.Errors:
-			_ = level.Error(logger).Log("err", err)
+			_ = level.Error(logger).Log("msg", "file watcher error", "err", err)
 		}
 	}
 }


### PR DESCRIPTION
This commit standardizes log messages across the codebase to ensure consistent field naming and formatting:

Key changes:
- Fixed printf-style formatting errors (e.g., "Unable to save %s\n\t%v")
- Standardized field names: "user" → "owner" throughout
- Added missing "msg" fields to error-only log entries
- Replaced fmt.Sprintf with structured fields for better log parsing
- Lowercased all log messages for consistency
- Added context fields (domain, issuer, owner, err) consistently

Files modified:
- certstore/certstore.go: Fixed printf-style logs, standardized field names
- certstore/account.go: Added missing msg fields, improved context
- certstore/startup.go: Replaced fmt.Sprintf with structured fields
- certstore/cleanup.go: Improved field structure and consistency
- certstore/watcher.go: Fixed message formatting and added context
- client/client.go: Changed all "user" fields to "owner"
- client/watcher.go: Added missing msg fields and context

All log statements now follow the pattern:
level.Log("msg", "action description", "field1", value1, "field2", value2, ...)

This improves:
- Log parsing and filtering capabilities
- Consistency across the application
- Debugging and troubleshooting efficiency