### PR TITLE
chore: bump go to 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ on:
       - 'README.md'
       - 'CHANGELOG.md'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,18 +19,18 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.26'
+        go-version-file: go.mod
 
     - name: Run linters
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
-        args: --timeout 10m
+        version: v2.12
+        args: --timeout=10m
 
     - name: Format
       run: make fmt
@@ -40,7 +40,7 @@ jobs:
 
     -
       name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v7
       with:
         distribution: goreleaser
         version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Run linters
       uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       -
@@ -22,12 +22,12 @@ jobs:
         run: git fetch --force --tags
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fgouteroux/acme-manager
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
Bumps the Go toolchain to 1.26 and refreshes the GitHub Actions used by CI and release.

## Go 1.26

- `go.mod`: `go 1.25.0` → `go 1.26.0`
- Both workflows now resolve the version from `go.mod` via `go-version-file`, instead of hardcoding it in two places. Future bumps only need the `go.mod` edit.

## Actions

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-go` | v5 | v7 |
| `golangci/golangci-lint-action` | v7 | v9 |
| `goreleaser/goreleaser-action` | v2 (CI) / v6 (release) | v7 |

This clears the Node 20 deprecation warnings that appeared throughout the logs, since the new majors run on node24. It also realigns `goreleaser-action`, which had drifted between the two workflows.

## Lint

- Pinned to `v2.12` instead of `latest`, so results are reproducible and a new upstream release cannot break CI unannounced. The existing `.golangci.yml` is already in v2 format, which the action has required since v7.
- `--timeout 10m` → `--timeout=10m`. The action splits arguments on spaces, so values have to be attached with `=`.

## Verification

`go build ./...` and `go vet ./...` pass on Go 1.26. `go test ./...` passes except `TestAPICreateCertificateHandler` and `TestAPIUpdateCertificateHandler`, which need a local Pebble ACME server on `localhost:14000`. Both fail identically with the `go` directive set back to 1.25, so they are unrelated to this change.

## Note on #19

This PR does not unblock #19. That failure is an OpenTelemetry version skew: the dependency group was bumped to `otel v1.44.0` / `sdk/log v0.20.0` while `contrib/exporters/autoexport` stayed at v0.61.0, which keeps `stdout/stdoutlog` pinned to the incompatible v0.12.2. Bumping `autoexport` to v0.69.0 pulls a coherent set and resolves it — that belongs in a separate dependency PR.
