### PR TITLE
chore: harden workflows and add a security policy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,15 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: go.mod
 
     - name: Run linters
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
         version: v2.12
         args: --timeout=10m
@@ -43,7 +43,7 @@ jobs:
 
     -
       name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v7
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
         distribution: goreleaser
         version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,20 @@ on:
     tags:
       - '*'
 
+# Least privilege at the workflow level; only the job that publishes the release
+# is granted write access to contents.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       -
@@ -22,12 +26,12 @@ jobs:
         run: git fetch --force --tags
       -
         name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version. Older tags are not
+patched; please upgrade before reporting an issue against them.
+
+| Version | Supported |
+|---------|-----------|
+| latest release | yes |
+| older releases | no |
+
+## Reporting a vulnerability
+
+Please report security issues privately rather than opening a public issue.
+
+Use [GitHub private vulnerability reporting](https://github.com/fgouteroux/acme-manager/security/advisories/new),
+which notifies the maintainer directly and keeps the discussion confidential
+until a fix is available.
+
+Include, as far as you can determine it:
+
+- the affected version or commit
+- the component involved (server, client, ring, Vault storage, an ACME issuer)
+- what an attacker can achieve, and what access they need to start
+- steps to reproduce, ideally with a minimal configuration
+
+You should get an acknowledgement within a few days. This is a single-maintainer
+project, so please allow reasonable time for a fix before disclosing publicly.
+
+## Scope
+
+ACME Manager issues and deploys TLS certificates, holds bearer tokens for its
+API, and stores private keys in Vault. Reports that are especially relevant:
+
+- authentication or authorisation bypass on the HTTP API
+- exposure of private keys, token values, or Vault credentials, including
+  through logs
+- a certificate being issued for, or delivered to, a party that does not own the
+  domain
+- path traversal or injection through certificate, issuer or owner names
+- cluster-level issues where one node can be made to act on another's behalf
+
+Out of scope: findings that require an already-compromised host or a valid
+administrative API key, vulnerabilities in a dependency that are not reachable
+from this code, and static-analysis reports without a demonstrated impact.


### PR DESCRIPTION
Addresses the three OpenSSF Scorecard checks that were scoring 0 and could be
fixed without changing how the project is maintained.

Verified by re-running Scorecard against this branch:

```
10  Pinned-Dependencies    all dependencies are pinned
10  Security-Policy        security policy file detected
10  Token-Permissions      GitHub workflow tokens follow principle of least privilege
```

All three previously scored 0.

## Token permissions

`release.yml` declared `contents: write` at the workflow level, so every step in
the workflow ran with a token that could write to the repository. The workflow
now defaults to `contents: read`, and `write` is granted only on the `goreleaser`
job, which needs it to publish the release. `ci.yaml` already had `contents: read`.

## Pinned actions

The seven action references are pinned to commit SHAs, with the tag kept as a
trailing comment for readability. A mutable tag can be repointed at new code by
whoever controls the action repository; a SHA cannot.

The trade-off is that pinned actions no longer pick up updates on their own. The
`github-actions` Dependabot group added earlier resolves SHAs, so updates will
still arrive as pull requests.

## Security policy

Adds `SECURITY.md`, pointing at GitHub private vulnerability reporting rather
than a public issue. The scope section is specific to what this project handles:
API authentication, private keys and token values including in logs, issuance
for domains the requester does not own, path traversal through certificate or
owner names, and cluster-level trust between nodes.

## Not addressed

Four checks stay at 0 because they are workflow or infrastructure decisions
rather than fixes: `Code-Review` (approved changesets), `Branch-Protection`,
`Signed-Releases` (cosign in GoReleaser) and `Fuzzing`.

Note also that no score is published for this repository yet — `api.scorecard.dev`
returns 404, and the badge renders as "invalid repo path". Publishing requires
the `ossf/scorecard-action` workflow with `publish_results: true` and
`id-token: write`, which is deliberately left out of this PR.
